### PR TITLE
Development

### DIFF
--- a/src/main/java/com/birthae/be/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/birthae/be/common/exception/GlobalExceptionHandler.java
@@ -23,16 +23,15 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ResponseMessage> handleBizRuntimeException(BizRuntimeException e) {
         log.error("BizRuntime Error: {}", e.getMessage(), e);
 
-        int statusCode = HttpStatus.BAD_REQUEST.value();
         String resultMessage = "처리 중 오류가 발생하였습니다: " + e.getMessage();
 
         ResponseMessage responseMessage = ResponseMessage.builder()
-                .statusCode(statusCode)
+                .statusCode(Integer.parseInt(e.getErrorCode()))
                 .resultMessage(resultMessage)
                 .detailMessage(e.getMessage())
                 .build();
 
-        return new ResponseEntity<>(responseMessage, HttpStatus.valueOf(statusCode));
+        return new ResponseEntity<>(responseMessage, HttpStatus.valueOf(Integer.parseInt(e.getErrorCode())));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/birthae/be/event/EventController.java
+++ b/src/main/java/com/birthae/be/event/EventController.java
@@ -2,6 +2,7 @@ package com.birthae.be.event;
 
 import com.birthae.be.common.dto.ResponseMessage;
 import com.birthae.be.event.dto.CreateEventRequestDto;
+import com.birthae.be.event.dto.UpdateEventRequestDto;
 import com.birthae.be.event.entity.Event;
 import com.birthae.be.security.UserDetailsImpl;
 import com.birthae.be.user.entity.User;
@@ -68,6 +69,50 @@ public class EventController {
                 .statusCode(HttpStatus.OK.value())
                 .resultMessage("이벤트 조회 성공")
                 .build();
+        return ResponseEntity.ok(responseMessage);
+    }
+
+    @PatchMapping(value = "/{eventId}", consumes = {"multipart/form-data"})
+    public ResponseEntity<ResponseMessage> updateEvent(
+            @PathVariable("eventId") Long eventId,
+            @ModelAttribute UpdateEventRequestDto request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        User user = userDetails.getUser();
+        String imageUrl = request.getImage() != null
+                ? s3Util.uploadFile(request.getImage(), "birthae/images/event")
+                : null;
+
+        Event updatedEvent = eventService.updateEvent(
+                eventId,
+                user.getUserId(),
+                request.getTitle(),
+                request.getDescription(),
+                imageUrl
+        );
+
+        ResponseMessage responseMessage = ResponseMessage.builder()
+                .data(updatedEvent)
+                .statusCode(HttpStatus.OK.value())
+                .resultMessage("이벤트 수정 성공")
+                .build();
+
+        return ResponseEntity.ok(responseMessage);
+    }
+
+    @DeleteMapping("/{eventId}")
+    public ResponseEntity<ResponseMessage> deleteEvent(
+            @PathVariable("eventId") Long eventId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        User user = userDetails.getUser();
+        eventService.deleteEvent(eventId, user.getUserId());
+
+        ResponseMessage responseMessage = ResponseMessage.builder()
+                .statusCode(HttpStatus.OK.value())
+                .resultMessage("이벤트 삭제 성공")
+                .build();
+
         return ResponseEntity.ok(responseMessage);
     }
 }

--- a/src/main/java/com/birthae/be/event/EventController.java
+++ b/src/main/java/com/birthae/be/event/EventController.java
@@ -7,10 +7,13 @@ import com.birthae.be.security.UserDetailsImpl;
 import com.birthae.be.user.entity.User;
 import com.birthae.be.utils.S3Util;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,7 +43,31 @@ public class EventController {
                 .resultMessage("이벤트 생성 성공")
                 .build();
 
-
         return ResponseEntity.status(HttpStatus.CREATED).body(responseMessage);
+    }
+
+    @GetMapping
+    public ResponseEntity<ResponseMessage> getAllEvents(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int pageSize
+    ) {
+        Page<Event> events = eventService.getAllEvents(page, pageSize);
+        ResponseMessage responseMessage = ResponseMessage.builder()
+                .data(events)
+                .statusCode(HttpStatus.OK.value())
+                .resultMessage("이벤트 목록 조회 성공")
+                .build();
+        return ResponseEntity.ok(responseMessage);
+    }
+
+    @GetMapping("/{eventId}")
+    public ResponseEntity<ResponseMessage> getEventById(@PathVariable("eventId") Long eventId) {
+        Event event = eventService.getEventById(eventId);
+        ResponseMessage responseMessage = ResponseMessage.builder()
+                .data(event)
+                .statusCode(HttpStatus.OK.value())
+                .resultMessage("이벤트 조회 성공")
+                .build();
+        return ResponseEntity.ok(responseMessage);
     }
 }

--- a/src/main/java/com/birthae/be/event/EventService.java
+++ b/src/main/java/com/birthae/be/event/EventService.java
@@ -1,9 +1,13 @@
 package com.birthae.be.event;
 
+import com.birthae.be.common.exception.BizRuntimeException;
 import com.birthae.be.event.entity.Event;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-
 
 @Service
 @RequiredArgsConstructor
@@ -17,5 +21,16 @@ public class EventService {
         newEvent.setDescription(description);
         newEvent.setImageUrl(imageUrl);
         return eventRepository.save(newEvent);
+    }
+
+    public Page<Event> getAllEvents(int page, int pageSize) {
+        Pageable pageable = PageRequest.of(page, pageSize);
+        return eventRepository.findAll(pageable);
+    }
+
+
+    public Event getEventById(Long eventId) {
+        return eventRepository.findById(eventId)
+                .orElseThrow(() -> new BizRuntimeException(String.valueOf(HttpStatus.NOT_FOUND.value()), "이벤트가 존재하지 않습니다."));
     }
 }

--- a/src/main/java/com/birthae/be/event/EventService.java
+++ b/src/main/java/com/birthae/be/event/EventService.java
@@ -28,9 +28,41 @@ public class EventService {
         return eventRepository.findAll(pageable);
     }
 
-
     public Event getEventById(Long eventId) {
         return eventRepository.findById(eventId)
                 .orElseThrow(() -> new BizRuntimeException(String.valueOf(HttpStatus.NOT_FOUND.value()), "이벤트가 존재하지 않습니다."));
+    }
+
+    public Event updateEvent(Long eventId, Long userId, String title, String description, String imageUrl) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new BizRuntimeException(String.valueOf(HttpStatus.NOT_FOUND.value()), "이벤트가 존재하지 않습니다."));
+
+        if (!event.getUserId().equals(userId)) {
+            throw new BizRuntimeException(String.valueOf(HttpStatus.FORBIDDEN.value()), "이벤트를 수정할 권한이 없습니다.");
+        }
+
+        if (title != null) {
+            event.setTitle(title);
+        }
+        if (description != null) {
+            event.setDescription(description);
+        }
+        if (imageUrl != null) {
+            event.setImageUrl(imageUrl);
+        }
+
+        return eventRepository.save(event);
+    }
+
+    public void deleteEvent(Long eventId, Long userId) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new BizRuntimeException(String.valueOf(HttpStatus.NOT_FOUND.value()), "이벤트가 존재하지 않습니다."));
+
+        if (!event.getUserId().equals(userId)) {
+            throw new BizRuntimeException(String.valueOf(HttpStatus.FORBIDDEN.value()), "이벤트를 삭제할 권한이 없습니다.");
+        }
+
+        event.setDltYsno("Y");
+        eventRepository.save(event);
     }
 }

--- a/src/main/java/com/birthae/be/event/dto/UpdateEventRequestDto.java
+++ b/src/main/java/com/birthae/be/event/dto/UpdateEventRequestDto.java
@@ -1,0 +1,15 @@
+package com.birthae.be.event.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateEventRequestDto {
+    private String title;
+    private String description;
+    private MultipartFile image;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#3 이벤트 기능 추가 완

## 📝작업 내용

이벤트 전체 조회, 단일조회, 수정, 삭제 기능 추가
- 이벤트 수정, 삭제 시 본인이 작성한 글이 아니면 수정 삭제할 수 없습니다.

### 스크린샷

1. 이벤트 수정

| 수정 성공 | 수정 실패 |
| --- | --- |
| ![수정 성공](https://github.com/user-attachments/assets/2c96a0f4-602c-4ce4-9903-b1e53bc548b6?raw=true) | ![수정 실패](https://github.com/user-attachments/assets/ab894782-8a37-41f8-80bf-ab8e47c287dd?raw=true) |

2. 이벤트 삭제

| 삭제 성공 | 삭제 실패 |
| --- | --- |
| ![삭제 성공](https://github.com/user-attachments/assets/12d62dde-0210-42c5-a8aa-5447883d0945?raw=true) | ![삭제 실패](https://github.com/user-attachments/assets/a7ddf8e1-5cf0-4437-946a-014cb7865160?raw=true) |
수정된 부분